### PR TITLE
Fix main file and improve package.json properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "greenworks",
+    "name": "@greenworksjs/greenworks",
     "version": "0.4.1",
     "description": "A node.js addon exposing Valve's Steamworks APIs to JavaScript",
     "main": "greenworks.js",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,21 @@
     "name": "greenworks",
     "version": "0.4.1",
     "description": "A node.js addon exposing Valve's Steamworks APIs to JavaScript",
-    "license": "UNLICENSED",
+    "main": "greenworks.js",
+    "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://wayward.visualstudio.com/Wayward/_git/greenworks"
+        "url": "https://github.com/greenworksjs/greenworks"
     },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://github.com/greenheartgames/greenworks/blob/master/LICENSE"
-        }
+    "bugs": {
+        "url": "https://github.com/greenworksjs/greenworks/issues"
+    },
+    "homepage": "https://github.com/greenworksjs/greenworks#readme",
+    "keywords": [
+        "steam",
+        "steamworks",
+        "greenworks",
+        "sdk"
     ],
     "dependencies": {
         "archiver": "2.1.1",


### PR DESCRIPTION
The "main": "greenworks.js" on package.json it's very important the lack of it can cause unexpected bugs when searching for the module.
I also fixed/added some missing properties that could be useful if we publish the package on npm.