### PR TITLE
Add time.h header

### DIFF
--- a/src/greenworks_zip.cc
+++ b/src/greenworks_zip.cc
@@ -50,6 +50,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
This will solve the compile error `note: forward declaration of ‘struct tm’.`

```
/usr/include/wchar.h:83:8: note: forward declaration of ‘struct tm’
   83 | struct tm;
      |        ^~
../src/greenworks_zip.cc:118:29: error: invalid use of incomplete type ‘struct tm’
  118 |     tmzip->tm_min = filedate->tm_min;
      |                             ^~
/usr/include/wchar.h:83:8: note: forward declaration of ‘struct tm’
   83 | struct tm;
      |        ^~
../src/greenworks_zip.cc:119:30: error: invalid use of incomplete type ‘struct tm’
  119 |     tmzip->tm_hour = filedate->tm_hour;
      |                              ^~
/usr/include/wchar.h:83:8: note: forward declaration of ‘struct tm’
   83 | struct tm;
      |        ^~
../src/greenworks_zip.cc:120:30: error: invalid use of incomplete type ‘struct tm’
  120 |     tmzip->tm_mday = filedate->tm_mday;
      |                              ^~
/usr/include/wchar.h:83:8: note: forward declaration of ‘struct tm’
   83 | struct tm;
      |        ^~
../src/greenworks_zip.cc:121:29: error: invalid use of incomplete type ‘struct tm’
  121 |     tmzip->tm_mon = filedate->tm_mon;
      |                             ^~
/usr/include/wchar.h:83:8: note: forward declaration of ‘struct tm’
   83 | struct tm;
      |        ^~
../src/greenworks_zip.cc:122:30: error: invalid use of incomplete type ‘struct tm’
  122 |     tmzip->tm_year = filedate->tm_year;
      |                              ^~
/usr/include/wchar.h:83:8: note: forward declaration of ‘struct tm’
   83 | struct tm;

```